### PR TITLE
Fix context usage and handle CLI errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"nimbus/internal/api"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -31,5 +32,8 @@ func main() {
 	clientCmd.Flags().StringP("host", "H", "http://localhost:8080", "URL of the host server")
 
 	rootCmd.AddCommand(serverCmd, clientCmd)
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/internal/api/handlers/handlers.go
+++ b/internal/api/handlers/handlers.go
@@ -90,7 +90,7 @@ func deleteRemovedServices(
 			err = env.Database.DeleteServiceById(ctx, service.ID)
 			if err != nil {
 				env.Logger.LogAttrs(
-					ctx, slog.LevelError, "Error deleting service in databse",
+					ctx, slog.LevelError, "Error deleting service in database",
 					slog.String("service", service.ServiceName), slog.Any("error", err),
 				)
 				http.Error(w, "Error deleting service", http.StatusInternalServerError)

--- a/internal/kubernetes/deployments.go
+++ b/internal/kubernetes/deployments.go
@@ -156,11 +156,11 @@ func GenerateDeploymentSpec(namespace string, service *models.Service, env *nimb
 func CreateDeployment(namespace string, deployment *appsv1.Deployment, env *nimbusEnv.Env) (*appsv1.Deployment, error) {
 	client := getClient(env).AppsV1().Deployments(namespace)
 
-	existing, err := client.Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	existing, err := client.Get(context.Background(), deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			env.Logger.Debug("Deployment not found, creating new one.", "name", deployment.Name)
-			return client.Create(context.TODO(), deployment, metav1.CreateOptions{})
+			return client.Create(context.Background(), deployment, metav1.CreateOptions{})
 		}
 		return nil, fmt.Errorf("failed to get deployment: %w", err)
 	}
@@ -173,7 +173,7 @@ func CreateDeployment(namespace string, deployment *appsv1.Deployment, env *nimb
 	existing.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
 	log.Printf("Updating deployment %s...", deployment.Name)
-	updated, err := client.Update(context.TODO(), existing, metav1.UpdateOptions{})
+	updated, err := client.Update(context.Background(), existing, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update deployment: %w", err)
 	}
@@ -184,7 +184,7 @@ func CreateDeployment(namespace string, deployment *appsv1.Deployment, env *nimb
 func DeleteDeployment(namespace, name string, env *nimbusEnv.Env) error {
 	client := getClient(env).AppsV1().Deployments(namespace)
 
-	err := client.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := client.Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete deployment: %w", err)
 	}

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -10,11 +10,11 @@ import (
 )
 
 func GetNamespace(name string, env *nimbusEnv.Env) (*corev1.Namespace, error) {
-	return getClient(env).CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	return getClient(env).CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
 }
 
 func CreateNamespace(name string, env *nimbusEnv.Env) error {
-	_, err := getClient(env).CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+	_, err := getClient(env).CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},

--- a/internal/kubernetes/services.go
+++ b/internal/kubernetes/services.go
@@ -83,11 +83,11 @@ func GenerateServiceSpec(namespace string, newService *models.Service, oldServic
 func CreateService(namespace string, service *corev1.Service, env *nimbusEnv.Env) (*corev1.Service, error) {
 	client := getClient(env).CoreV1().Services(namespace)
 
-	existing, err := client.Get(context.TODO(), service.Name, metav1.GetOptions{})
+	existing, err := client.Get(context.Background(), service.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Printf("Service %s not found, creating new one.", service.Name)
-			return client.Create(context.TODO(), service, metav1.CreateOptions{})
+			return client.Create(context.Background(), service, metav1.CreateOptions{})
 		}
 		return nil, fmt.Errorf("failed to get service: %w", err)
 	}
@@ -100,7 +100,7 @@ func CreateService(namespace string, service *corev1.Service, env *nimbusEnv.Env
 	existing.Annotations["updated"] = time.Now().Format(time.RFC3339)
 
 	log.Printf("Updating service %s...", service.Name)
-	updated, err := client.Update(context.TODO(), existing, metav1.UpdateOptions{})
+	updated, err := client.Update(context.Background(), existing, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update deployment: %w", err)
 	}
@@ -111,7 +111,7 @@ func CreateService(namespace string, service *corev1.Service, env *nimbusEnv.Env
 func DeleteService(namespace, name string, env *nimbusEnv.Env) error {
 	client := getClient(env).CoreV1().Services(namespace)
 
-	err := client.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := client.Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete service: %w", err)
 	}

--- a/internal/kubernetes/volumes.go
+++ b/internal/kubernetes/volumes.go
@@ -31,7 +31,7 @@ func GetVolumeIdentifiers(namespace string, service *models.Service, env *nimbus
 			volume.Size = 100 // default to 100Mi
 		}
 
-		identifier, err := env.Database.GetVolumeIdentifier(context.TODO(), database.GetVolumeIdentifierParams{
+		identifier, err := env.Database.GetVolumeIdentifier(context.Background(), database.GetVolumeIdentifierParams{
 			VolumeName:    volume.Name,
 			ProjectID:     env.Deployment.ProjectID,
 			ProjectBranch: env.Deployment.BranchName,
@@ -43,7 +43,7 @@ func GetVolumeIdentifiers(namespace string, service *models.Service, env *nimbus
 				log.Printf("Error creating PVC: %s\n", err)
 				return nil, err
 			}
-			_, err := env.Database.CreateVolume(context.TODO(), database.CreateVolumeParams{
+			_, err := env.Database.CreateVolume(context.Background(), database.CreateVolumeParams{
 				Identifier:    identifier,
 				VolumeName:    volume.Name,
 				ProjectID:     env.Deployment.ProjectID,
@@ -75,7 +75,7 @@ func GetVolumeIdentifiers(namespace string, service *models.Service, env *nimbus
 func CheckPVC(namespace string, name string, env *nimbusEnv.Env) bool {
 	client := getClient(env).CoreV1().PersistentVolumeClaims(namespace)
 
-	_, err := client.Get(context.TODO(), name, metav1.GetOptions{})
+	_, err := client.Get(context.Background(), name, metav1.GetOptions{})
 	return err == nil
 }
 
@@ -83,7 +83,7 @@ func CreatePVC(namespace string, identifier uuid.UUID, size int32, env *nimbusEn
 	client := getClient(env).CoreV1().PersistentVolumeClaims(namespace)
 
 	storageClass := os.Getenv("NIMBUS_STORAGE_CLASS")
-	_, err := client.Create(context.TODO(), &corev1.PersistentVolumeClaim{
+	_, err := client.Create(context.Background(), &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("pvc-%s", identifier.String()),
 			Namespace: namespace,
@@ -107,6 +107,6 @@ func CreatePVC(namespace string, identifier uuid.UUID, size int32, env *nimbusEn
 func DeletePVC(namespace string, name string, env *nimbusEnv.Env) error {
 	client := getClient(env).CoreV1().PersistentVolumeClaims(namespace)
 
-	err := client.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := client.Delete(context.Background(), name, metav1.DeleteOptions{})
 	return err
 }


### PR DESCRIPTION
## Summary
- replace `context.TODO()` calls with `context.Background()`
- handle errors from `cobra` root command execution
- fix typo in handlers log message

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ede5796c08325901a8159a82e598c