### PR TITLE
Add project and service management endpoints and CLI features

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -142,4 +142,8 @@ func addRoutes(router *mux.Router) {
 	}).Methods("GET")
 
 	router.HandleFunc("/deploy", handlers.Deploy).Methods("POST")
+	router.HandleFunc("/projects", handlers.CreateProject).Methods("POST")
+	router.HandleFunc("/projects", handlers.GetProjects).Methods("GET")
+	router.HandleFunc("/services", handlers.GetServices).Methods("GET")
+	router.HandleFunc("/services/{name}", handlers.GetService).Methods("GET")
 }

--- a/internal/api/handlers/responses.go
+++ b/internal/api/handlers/responses.go
@@ -1,5 +1,29 @@
 package handlers
 
+import "nimbus/internal/database"
+
 type deployResponse struct {
 	Urls map[string][]string `json:"services"`
+}
+
+type projectsResponse struct {
+	Projects []database.Project `json:"projects"`
+}
+
+type servicesResponse struct {
+	Services []database.GetServicesByUserRow `json:"services"`
+}
+
+type podStatus struct {
+	Name  string `json:"name"`
+	Phase string `json:"phase"`
+}
+
+type serviceDetailResponse struct {
+	Project     string      `json:"project"`
+	Branch      string      `json:"branch"`
+	Name        string      `json:"name"`
+	NodePorts   []int32     `json:"nodePorts"`
+	Ingress     *string     `json:"ingress,omitempty"`
+	PodStatuses []podStatus `json:"pods"`
 }

--- a/internal/kubernetes/pods.go
+++ b/internal/kubernetes/pods.go
@@ -1,0 +1,19 @@
+package kubernetes
+
+import (
+	nimbusEnv "nimbus/internal/env"
+
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetPods(namespace, serviceName string, env *nimbusEnv.Env) ([]corev1.Pod, error) {
+	pods, err := getClient(env).CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=" + serviceName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}

--- a/query.sql
+++ b/query.sql
@@ -84,3 +84,25 @@ SELECT EXISTS (
 -- name: DeleteUnusedVolumes :exec
 DELETE FROM volumes
 WHERE project_id = $1 AND project_branch = $2 AND NOT volume_name = ANY($3::text[]);
+
+-- name: GetProjectsByUser :many
+SELECT p.* FROM projects p
+JOIN user_projects up ON p.id = up.project_id
+WHERE up.user_id = $1
+ORDER BY p.name;
+
+-- name: GetServicesByUser :many
+SELECT s.*, p.name AS project_name FROM services s
+JOIN projects p ON s.project_id = p.id
+JOIN user_projects up ON up.project_id = p.id
+WHERE up.user_id = $1
+ORDER BY p.name, s.service_name;
+
+-- name: GetServiceByName :one
+SELECT * FROM services
+WHERE service_name = $1 AND project_id = $2 AND project_branch = $3
+LIMIT 1;
+
+-- name: AddUserToProject :exec
+INSERT INTO user_projects (user_id, project_id)
+VALUES ($1, $2);


### PR DESCRIPTION
## Summary
- implement endpoints for project and service management
- add kubernetes pod listing helper
- extend CLI to create/list projects and list/get services
- regenerate SQL for new queries
- fix import ordering

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875389c2cb8832581da41b6eebab336