### PR TITLE
Add service log streaming and status info

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -146,5 +146,6 @@ func addRoutes(router *mux.Router) {
 	router.HandleFunc("/projects", handlers.GetProjects).Methods("GET")
 	router.HandleFunc("/services", handlers.GetServices).Methods("GET")
 	router.HandleFunc("/services/{name}", handlers.GetService).Methods("GET")
+	router.HandleFunc("/services/{name}/logs", handlers.StreamLogs).Methods("GET")
 	router.HandleFunc("/branch", handlers.DeleteBranch).Methods("DELETE")
 }

--- a/internal/api/handlers/responses.go
+++ b/internal/api/handlers/responses.go
@@ -10,8 +10,15 @@ type projectsResponse struct {
 	Projects []database.Project `json:"projects"`
 }
 
+type serviceListItem struct {
+	ProjectName   string `json:"project"`
+	ProjectBranch string `json:"branch"`
+	ServiceName   string `json:"name"`
+	Status        string `json:"status"`
+}
+
 type servicesResponse struct {
-	Services []database.GetServicesByUserRow `json:"services"`
+	Services []serviceListItem `json:"services"`
 }
 
 type podStatus struct {

--- a/internal/kubernetes/pods.go
+++ b/internal/kubernetes/pods.go
@@ -4,6 +4,8 @@ import (
 	nimbusEnv "nimbus/internal/env"
 
 	"context"
+	"fmt"
+	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,4 +18,28 @@ func GetPods(namespace, serviceName string, env *nimbusEnv.Env) ([]corev1.Pod, e
 		return nil, err
 	}
 	return pods.Items, nil
+}
+
+// StreamPodLogs streams logs for a specific pod within a namespace. The caller
+// should close the returned ReadCloser when finished.
+func StreamPodLogs(namespace, podName string, env *nimbusEnv.Env) (io.ReadCloser, error) {
+	req := getClient(env).CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Follow: true})
+	stream, err := req.Stream(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to stream logs: %w", err)
+	}
+	return stream, nil
+}
+
+// StreamServiceLogs retrieves the first pod for the given service and streams
+// its logs. If no pods are found an error is returned.
+func StreamServiceLogs(namespace, serviceName string, env *nimbusEnv.Env) (io.ReadCloser, error) {
+	pods, err := GetPods(namespace, serviceName, env)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods found for service %s", serviceName)
+	}
+	return StreamPodLogs(namespace, pods[0].Name, env)
 }


### PR DESCRIPTION
## Summary
- allow streaming logs from a service via new CLI and API route
- show pod status in `service list` output
- display NodePorts with hostname

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687558cdc44c832585fc4dbf21727f87