### PR TITLE
Add project delete endpoint and fix log streaming

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -147,5 +147,6 @@ func addRoutes(router *mux.Router) {
 	router.HandleFunc("/services", handlers.GetServices).Methods("GET")
 	router.HandleFunc("/services/{name}", handlers.GetService).Methods("GET")
 	router.HandleFunc("/services/{name}/logs", handlers.StreamLogs).Methods("GET")
+	router.HandleFunc("/projects/{name}", handlers.DeleteProject).Methods("DELETE")
 	router.HandleFunc("/branch", handlers.DeleteBranch).Methods("DELETE")
 }

--- a/internal/database/query.sql.go
+++ b/internal/database/query.sql.go
@@ -186,6 +186,32 @@ func (q *Queries) GetProject(ctx context.Context, id uuid.UUID) (Project, error)
 	return i, err
 }
 
+const getProjectBranches = `-- name: GetProjectBranches :many
+SELECT project_branch FROM services s WHERE s.project_id = $1
+UNION
+SELECT project_branch FROM volumes v WHERE v.project_id = $1
+`
+
+func (q *Queries) GetProjectBranches(ctx context.Context, projectID uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, getProjectBranches, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var project_branch string
+		if err := rows.Scan(&project_branch); err != nil {
+			return nil, err
+		}
+		items = append(items, project_branch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getProjectByName = `-- name: GetProjectByName :one
 SELECT id, name FROM projects
 WHERE name = $1 LIMIT 1

--- a/query.sql
+++ b/query.sql
@@ -106,3 +106,8 @@ LIMIT 1;
 -- name: AddUserToProject :exec
 INSERT INTO user_projects (user_id, project_id)
 VALUES ($1, $2);
+
+-- name: GetProjectBranches :many
+SELECT project_branch FROM services s WHERE s.project_id = $1
+UNION
+SELECT project_branch FROM volumes v WHERE v.project_id = $1;


### PR DESCRIPTION
## Summary
- implement a new `GetProjectBranches` query
- add API endpoint and CLI command for deleting a project
- clean up all branches, services and volumes when deleting a project
- fix log streaming by streaming tail lines with follow

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875649d9ef08325879d87c2460c52e5