### PR TITLE
add architecture field with node affinity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Each service defined in your deployment file accepts a `public` flag. When set
 to `true`, Nimbus exposes the service publicly via a NodePort or Ingress.
 Without this flag, services are created as `ClusterIP` and remain internal only.
 
+Services can also specify an `arch` field with either `amd64` or `arm64` to
+target a specific node architecture. Nimbus applies a matching node affinity so
+pods only run on nodes with the selected architecture.
+
 ## Contributing
 
 We welcome contributions! Feel free to submit issues and pull requests to improve Nimbus.

--- a/internal/kubernetes/deployments.go
+++ b/internal/kubernetes/deployments.go
@@ -144,6 +144,26 @@ func GenerateDeploymentSpec(namespace string, service *models.Service, env *nimb
 		}
 	}
 
+	if service.Arch != "" {
+		spec.Template.Spec.Affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "kubernetes.io/arch",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{service.Arch},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service.Name,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -24,6 +24,7 @@ type Service struct {
 	Public       bool            `yaml:"public,omitempty"`
 	Template     string          `yaml:"template,omitempty"`
 	Version      string          `yaml:"version,omitempty"`
+	Arch         string          `yaml:"arch,omitempty"`
 	Configs      []ConfigEntry   `yaml:"configs,omitempty"`
 	Command      []string        `yaml:"command,omitempty"`
 	Args         []string        `yaml:"args,omitempty"`


### PR DESCRIPTION
## Summary
- add new `arch` field in service model
- document the `arch` option in README
- apply node affinity based on the `arch` field when generating deployments

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875d5d12cac83259018d5e21f7aabe7