### PR TITLE
Disable previews using config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Ensure that your cluster has a properly configured NFS provisioner before deploy
 
 You also need to set the environment variable `NIMBUS_STORAGE_CLASS` with the name of the storage class you have configured with the provisioner. By default, this is set to `nfs-client`.
 
+To restrict deployments to only the `main` or `master` branches for a project, add `allowBranchPreviews: false` to your project's `nimbus.yaml`. When disabled, deploy requests from any other branch will be rejected.
+
 ## Local Development
 
 For local development, follow these steps:

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Config struct {
-	AppName  string    `yaml:"app"`
-	Services []Service `yaml:"services"`
+	AppName             string    `yaml:"app"`
+	AllowBranchPreviews bool      `yaml:"allowBranchPreviews,omitempty"`
+	Services            []Service `yaml:"services"`
 }
 
 type Service struct {


### PR DESCRIPTION
## Summary
- add `allowBranchPreviews` option in project config
- remove `NIMBUS_ALLOW_BRANCH_PREVIEWS` env var
- reject preview deploys when config disables them
- document new YAML setting

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875ebb649ec8325a2e57449435b8eb4