### PR TITLE
Enable branch previews by default

### DIFF
--- a/internal/api/handlers/request.go
+++ b/internal/api/handlers/request.go
@@ -82,6 +82,10 @@ func buildDeployRequest(w http.ResponseWriter, r *http.Request, env *nimbusEnv.E
 		http.Error(w, "Error parsing YAML", http.StatusBadRequest)
 		return nil, nil, err
 	}
+	if config.AllowBranchPreviews == nil {
+		v := true
+		config.AllowBranchPreviews = &v
+	}
 
 	env.Logger.DebugContext(ctx, "Retrieving user by API key")
 	user, err := env.Database.GetUserByApiKey(r.Context(), apiKey)
@@ -132,7 +136,7 @@ func buildDeployRequest(w http.ResponseWriter, r *http.Request, env *nimbusEnv.E
 	}
 	ctx = logging.AppendCtx(ctx, slog.String("branch", branch))
 
-	if !config.AllowBranchPreviews && branch != "main" && branch != "master" {
+	if config.AllowBranchPreviews != nil && !*config.AllowBranchPreviews && branch != "main" && branch != "master" {
 		http.Error(w, "branch previews are disabled", http.StatusBadRequest)
 		return nil, nil, fmt.Errorf("branch previews disabled")
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -10,7 +10,7 @@ import (
 
 type Config struct {
 	AppName             string    `yaml:"app"`
-	AllowBranchPreviews bool      `yaml:"allowBranchPreviews,omitempty"`
+	AllowBranchPreviews *bool     `yaml:"allowBranchPreviews,omitempty"`
 	Services            []Service `yaml:"services"`
 }
 


### PR DESCRIPTION
## Summary
- allow omission of `allowBranchPreviews` in `nimbus.yaml` to default to true
- update deploy handler to set the default and handle the pointer

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6876bed8c90483259c197d4e519ff487