### PR TITLE
fix: resolve nil pointer panic in deploy and all authenticated endpoints

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -36,6 +36,7 @@ func Start(port string, env *env.Env) error {
 	router.Use(middleware.InjectEnvironment(env))
 	router.Use(middleware.Recover)
 	router.Use(middleware.LogRequest)
+	router.Use(middleware.Authenticate)
 	router.Use(oapimw.OapiRequestValidatorWithOptions(swagger, &oapimw.Options{
 		Options: openapi3filter.Options{
 			AuthenticationFunc: middleware.OAPIAuthFunc,

--- a/internal/api/middleware/middleware.go
+++ b/internal/api/middleware/middleware.go
@@ -102,6 +102,38 @@ func LogRequest(next http.Handler) http.Handler {
 	})
 }
 
+// Authenticate reads the X-API-Key header, looks up the user, and injects the
+// user into the request context. This runs as a standard mux middleware so the
+// modified request is properly propagated to downstream handlers.
+//
+// The oapi-codegen nethttp-middleware (v1.1.2) passes the original *http.Request
+// to the next handler after validation, discarding any context modifications made
+// inside the AuthenticationFunc. By performing user injection here instead, the
+// user context is guaranteed to reach the handler.
+func Authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.Header.Get("X-API-Key")
+		if apiKey == "" {
+			// No API key provided — let the OAPI validator decide whether
+			// the endpoint requires auth and return the appropriate error.
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		e := env.FromContext(r.Context())
+		user, err := e.Database.GetUserByApiKey(r.Context(), apiKey)
+		if err != nil {
+			// Key lookup failed — skip injection, let the OAPI auth
+			// function handle the error response.
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		r = r.WithContext(database.UserWithContext(r.Context(), &user))
+		next.ServeHTTP(w, r)
+	})
+}
+
 // OAPIErrorHandler handles errors from oapi-codegen middleware and formats them
 // according to your error schema.
 func OAPIErrorHandler(
@@ -145,6 +177,10 @@ func OAPIErrorHandler(
 }
 
 // OAPIAuthFunc is the authentication function for oapi-codegen middleware.
+// It validates the API key and confirms the user exists. The actual user
+// injection into context is handled by the Authenticate middleware, which
+// runs earlier in the middleware chain and properly propagates the modified
+// request to downstream handlers.
 func OAPIAuthFunc(ctx context.Context, input *openapi3filter.AuthenticationInput) error {
 	switch input.SecuritySchemeName {
 	case "ApiKeyAuth":
@@ -168,9 +204,12 @@ func OAPIAuthFunc(ctx context.Context, input *openapi3filter.AuthenticationInput
 		}
 	}
 
-	// Validate API key
+	// Validate API key — user lookup is intentionally done here as well for
+	// proper OpenAPI security-scheme error responses (401 for bad keys).
+	// The Authenticate middleware already injected the user into context if
+	// the key was valid, so this is a validation-only check.
 	env.Logger.DebugContext(ctx, "checking api key existence")
-	user, err := env.Database.GetUserByApiKey(ctx, apiKey)
+	_, err := env.Database.GetUserByApiKey(ctx, apiKey)
 	if errors.Is(err, pgx.ErrNoRows) {
 		env.Logger.ErrorContext(ctx, "no user found", slog.Any("error", err))
 		env.Logger.ErrorContext(ctx, "api key does not exist")
@@ -189,14 +228,6 @@ func OAPIAuthFunc(ctx context.Context, input *openapi3filter.AuthenticationInput
 			ErrorID: requestID,
 		}
 	}
-
-	// Inject user
-	input.RequestValidationInput.Request = input.RequestValidationInput.Request.WithContext(
-		database.UserWithContext(
-			input.RequestValidationInput.Request.Context(),
-			&user,
-		),
-	)
 
 	return nil
 }

--- a/internal/api/openapi/branch.go
+++ b/internal/api/openapi/branch.go
@@ -20,6 +20,14 @@ func (Server) DeleteBranch(ctx context.Context, request DeleteBranchRequestObjec
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return DeleteBranch401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	// Get project
 	env.Logger.DebugContext(ctx, "getting project")

--- a/internal/api/openapi/deploy.go
+++ b/internal/api/openapi/deploy.go
@@ -171,6 +171,14 @@ func (Server) PostDeploy(
 	// Check user permissions
 	env.Logger.DebugContext(ctx, "checking user project access")
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return PostDeploy401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestID,
+		}, nil
+	}
 	authorized, err := env.Database.IsUserInProject(ctx, database.IsUserInProjectParams{
 		UserID:    user.ID,
 		ProjectID: project.ID,

--- a/internal/api/openapi/projects.go
+++ b/internal/api/openapi/projects.go
@@ -24,6 +24,14 @@ func (Server) GetProjects(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return GetProjects401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	dbProjects, err := env.Database.GetProjectsByUser(ctx, user.ID)
 	if err != nil {
@@ -61,6 +69,14 @@ func (Server) DeleteProjectsName(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return DeleteProjectsName401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	// Get project
 	env.Logger.DebugContext(ctx, "getting project")
@@ -236,6 +252,14 @@ func (Server) GetProjectsNameSecrets(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return GetProjectsNameSecrets401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	// Get project
 	env.Logger.DebugContext(ctx, "getting project")
@@ -347,6 +371,14 @@ func (Server) PutProjectsNameSecrets(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return PutProjectsNameSecrets401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	// Get project
 	env.Logger.DebugContext(ctx, "getting project")

--- a/internal/api/openapi/services.go
+++ b/internal/api/openapi/services.go
@@ -61,6 +61,14 @@ func (Server) GetServices(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return GetServices401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	services, err := env.Database.GetServicesByUser(ctx, user.ID)
 	if err != nil {
@@ -104,6 +112,14 @@ func (Server) GetServicesName(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return GetServicesName401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	var branch string
 	if request.Params.Branch != nil {
@@ -272,6 +288,14 @@ func (Server) GetServicesNameLogs(
 	env := env.FromContext(ctx)
 	requestid := fmt.Sprintf("%d", requestid.FromContext(ctx))
 	user := database.UserFromContext(ctx)
+	if user == nil {
+		return GetServicesNameLogs401JSONResponse{
+			Status:  apierror.InvalidAPIKey.Status(),
+			Code:    apierror.InvalidAPIKey.String(),
+			Message: "authentication required",
+			ErrorId: requestid,
+		}, nil
+	}
 
 	var branch string
 	if request.Params.Branch != nil {


### PR DESCRIPTION
The oapi-codegen nethttp-middleware (v1.1.2) passes the original *http.Request to the next handler after validation, discarding any context modifications made inside the AuthenticationFunc. This meant the user injected via database.UserWithContext in OAPIAuthFunc was lost by the time handlers called database.UserFromContext, causing a nil pointer dereference panic on every authenticated request.

Fix:
- Add Authenticate middleware that runs before the OAPI validator in the mux chain, reading the X-API-Key header, looking up the user, and injecting into context via the standard request propagation path.
- Keep OAPIAuthFunc for OpenAPI security-scheme validation (returns proper 401 for invalid/missing keys).
- Add defensive nil guards on UserFromContext in all handlers as a safety net.