### PR TITLE
feat: track commit hash per deployment

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -89,6 +89,10 @@ paths:
                   type: string
                   description: The branch name to deploy (defaults to 'main')
                   example: main
+                commit:
+                  type: string
+                  description: The git commit hash for this deployment
+                  example: abc123def456
 
       responses:
         "200":
@@ -735,11 +739,16 @@ components:
             - Succeeded
             - Failed
             - Unknown
+        commit_hash:
+          type: string
+          nullable: true
+          description: The git commit hash of the current deployment
       example:
         project: my-app
         branch: main
         name: web
         status: Running
+        commit_hash: abc123def456
 
     PodStatus:
       type: object
@@ -782,6 +791,10 @@ components:
           type: string
           nullable: true
           description: The ingress hostname (if applicable)
+        commit_hash:
+          type: string
+          nullable: true
+          description: The git commit hash of the current deployment
         pod_statuses:
           type: array
           items:
@@ -796,6 +809,7 @@ components:
         name: web
         nodePorts: [30001, 30002]
         ingress: web.example.com
+        commit_hash: abc123def456
         pods:
           - name: web-deployment-abc123
             phase: Running

--- a/internal/api/openapi/deploy.go
+++ b/internal/api/openapi/deploy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -171,6 +172,12 @@ func parseDeployForm(
 	} else {
 		deployRequest.BranchName = branches[0]
 	}
+
+	// Read commit hash
+	commits := form.Value["commit"]
+	if len(commits) > 0 && commits[0] != "" {
+		deployRequest.CommitHash = commits[0]
+	}
 	if config.AllowBranchPreviews != nil &&
 		!*config.AllowBranchPreviews &&
 		!utils.IsMainBranch(deployRequest.BranchName) {
@@ -292,6 +299,12 @@ func deployService(
 		}
 	}
 
+	// Build commit hash for DB storage
+	commitHash := pgtype.Text{}
+	if deployRequest.CommitHash != "" {
+		commitHash = pgtype.Text{String: deployRequest.CommitHash, Valid: true}
+	}
+
 	// Ensure DB record exists
 	svcExists := existingService != nil
 	var newSvc database.Service
@@ -302,9 +315,17 @@ func deployService(
 			ProjectID:     deployRequest.ProjectID,
 			ProjectBranch: deployRequest.BranchName,
 			ServiceName:   serviceConfig.Name,
+			CommitHash:    commitHash,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("creating service in database for %s: %w", serviceConfig.Name, err)
+		}
+	} else {
+		if err := env.Database.SetServiceCommitHash(ctx, database.SetServiceCommitHashParams{
+			ID:         existingService.ID,
+			CommitHash: commitHash,
+		}); err != nil {
+			return nil, fmt.Errorf("updating commit hash for %s: %w", serviceConfig.Name, err)
 		}
 	}
 
@@ -474,6 +495,24 @@ func (Server) PostDeploy(
 	if err := deleteStaleServices(ctx, deployRequest.Namespace, existingServices, serviceNames, env.Database); err != nil {
 		slog.ErrorContext(ctx, "failed to delete stale services", "error", err)
 		return PostDeploy500JSONResponse(internalError(rid)), nil
+	}
+
+	// Rewrite image tags with commit hash for non-template services
+	if deployRequest.CommitHash != "" {
+		for i, serviceConfig := range config.Services {
+			switch serviceConfig.Template {
+			case "postgres", "redis":
+				continue
+			}
+			if serviceConfig.Image == "" {
+				continue
+			}
+			repo := serviceConfig.Image
+			if idx := strings.LastIndex(repo, ":"); idx != -1 {
+				repo = repo[:idx]
+			}
+			config.Services[i].Image = repo + ":" + deployRequest.CommitHash
+		}
 	}
 
 	// Deploy each service

--- a/internal/api/openapi/gen.go
+++ b/internal/api/openapi/gen.go
@@ -97,6 +97,9 @@ type ServiceDetail struct {
 	// Branch The branch name
 	Branch *string `json:"branch,omitempty"`
 
+	// CommitHash The git commit hash of the current deployment
+	CommitHash nullable.Nullable[string] `json:"commit_hash,omitempty"`
+
 	// Ingress The ingress hostname (if applicable)
 	Ingress nullable.Nullable[string] `json:"ingress,omitempty"`
 
@@ -120,6 +123,9 @@ type ServiceDetail struct {
 type ServiceListItem struct {
 	// Branch The branch name
 	Branch *string `json:"branch,omitempty"`
+
+	// CommitHash The git commit hash of the current deployment
+	CommitHash nullable.Nullable[string] `json:"commit_hash,omitempty"`
 
 	// Name The service name
 	Name *string `json:"name,omitempty"`
@@ -150,6 +156,9 @@ type DeleteBranchParams struct {
 type PostDeployMultipartBody struct {
 	// Branch The branch name to deploy (defaults to 'main')
 	Branch *string `json:"branch,omitempty"`
+
+	// Commit The git commit hash for this deployment
+	Commit *string `json:"commit,omitempty"`
 
 	// File The nimbus.yaml configuration file
 	File openapi_types.File `json:"file"`

--- a/internal/api/openapi/services.go
+++ b/internal/api/openapi/services.go
@@ -83,12 +83,16 @@ func (Server) GetServices(
 		} else {
 			status = ServiceListItemStatusUnknown
 		}
-		items = append(items, ServiceListItem{
+		item := ServiceListItem{
 			Project: &svc.ProjectName,
 			Branch:  &svc.ProjectBranch,
 			Name:    &svc.ServiceName,
 			Status:  &status,
-		})
+		}
+		if svc.CommitHash.Valid {
+			item.CommitHash = nullable.NewNullableWithValue(svc.CommitHash.String)
+		}
+		items = append(items, item)
 	}
 
 	return GetServices200JSONResponse{
@@ -234,6 +238,10 @@ func (Server) GetServicesName(
 
 	if svc.Ingress.Valid {
 		res.Ingress = nullable.NewNullableWithValue(svc.Ingress.String)
+	}
+
+	if svc.CommitHash.Valid {
+		res.CommitHash = nullable.NewNullableWithValue(svc.CommitHash.String)
 	}
 
 	return res, nil

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -21,6 +21,7 @@ type Service struct {
 	ServiceName   string
 	NodePorts     []int32
 	Ingress       pgtype.Text
+	CommitHash    pgtype.Text
 }
 
 type User struct {

--- a/internal/database/querier.go
+++ b/internal/database/querier.go
@@ -36,6 +36,7 @@ type Querier interface {
 	GetUserByUsername(ctx context.Context, username string) (User, error)
 	GetVolumeIdentifier(ctx context.Context, arg GetVolumeIdentifierParams) (uuid.UUID, error)
 	IsUserInProject(ctx context.Context, arg IsUserInProjectParams) (bool, error)
+	SetServiceCommitHash(ctx context.Context, arg SetServiceCommitHashParams) error
 	SetServiceIngress(ctx context.Context, arg SetServiceIngressParams) error
 	SetServiceNodePorts(ctx context.Context, arg SetServiceNodePortsParams) error
 }

--- a/internal/database/queriermock.go
+++ b/internal/database/queriermock.go
@@ -381,6 +381,20 @@ func (mr *MockQuerierMockRecorder) IsUserInProject(ctx, arg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUserInProject", reflect.TypeOf((*MockQuerier)(nil).IsUserInProject), ctx, arg)
 }
 
+// SetServiceCommitHash mocks base method.
+func (m *MockQuerier) SetServiceCommitHash(ctx context.Context, arg SetServiceCommitHashParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetServiceCommitHash", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetServiceCommitHash indicates an expected call of SetServiceCommitHash.
+func (mr *MockQuerierMockRecorder) SetServiceCommitHash(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetServiceCommitHash", reflect.TypeOf((*MockQuerier)(nil).SetServiceCommitHash), ctx, arg)
+}
+
 // SetServiceIngress mocks base method.
 func (m *MockQuerier) SetServiceIngress(ctx context.Context, arg SetServiceIngressParams) error {
 	m.ctrl.T.Helper()

--- a/internal/database/query.sql.go
+++ b/internal/database/query.sql.go
@@ -66,10 +66,10 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 }
 
 const createService = `-- name: CreateService :one
-INSERT INTO services (id, project_id, project_branch, service_name, node_ports, ingress)
-  VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO services (id, project_id, project_branch, service_name, node_ports, ingress, commit_hash)
+  VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 `
 
 type CreateServiceParams struct {
@@ -79,6 +79,7 @@ type CreateServiceParams struct {
 	ServiceName   string
 	NodePorts     []int32
 	Ingress       pgtype.Text
+	CommitHash    pgtype.Text
 }
 
 func (q *Queries) CreateService(ctx context.Context, arg CreateServiceParams) (Service, error) {
@@ -89,6 +90,7 @@ func (q *Queries) CreateService(ctx context.Context, arg CreateServiceParams) (S
 		arg.ServiceName,
 		arg.NodePorts,
 		arg.Ingress,
+		arg.CommitHash,
 	)
 	var i Service
 	err := row.Scan(
@@ -98,6 +100,7 @@ func (q *Queries) CreateService(ctx context.Context, arg CreateServiceParams) (S
 		&i.ServiceName,
 		&i.NodePorts,
 		&i.Ingress,
+		&i.CommitHash,
 	)
 	return i, err
 }
@@ -351,7 +354,7 @@ func (q *Queries) GetProjectsByUser(ctx context.Context, userID uuid.UUID) ([]Pr
 
 const getService = `-- name: GetService :one
 SELECT
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 FROM
   services
 WHERE
@@ -369,13 +372,14 @@ func (q *Queries) GetService(ctx context.Context, id uuid.UUID) (Service, error)
 		&i.ServiceName,
 		&i.NodePorts,
 		&i.Ingress,
+		&i.CommitHash,
 	)
 	return i, err
 }
 
 const getServiceByName = `-- name: GetServiceByName :one
 SELECT
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 FROM
   services
 WHERE
@@ -401,13 +405,14 @@ func (q *Queries) GetServiceByName(ctx context.Context, arg GetServiceByNamePara
 		&i.ServiceName,
 		&i.NodePorts,
 		&i.Ingress,
+		&i.CommitHash,
 	)
 	return i, err
 }
 
 const getServicesByProject = `-- name: GetServicesByProject :many
 SELECT
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 FROM
   services
 WHERE
@@ -438,6 +443,7 @@ func (q *Queries) GetServicesByProject(ctx context.Context, arg GetServicesByPro
 			&i.ServiceName,
 			&i.NodePorts,
 			&i.Ingress,
+			&i.CommitHash,
 		); err != nil {
 			return nil, err
 		}
@@ -451,7 +457,7 @@ func (q *Queries) GetServicesByProject(ctx context.Context, arg GetServicesByPro
 
 const getServicesByUser = `-- name: GetServicesByUser :many
 SELECT
-  s.id, s.project_id, s.project_branch, s.service_name, s.node_ports, s.ingress,
+  s.id, s.project_id, s.project_branch, s.service_name, s.node_ports, s.ingress, s.commit_hash,
   p.name AS project_name
 FROM
   services s
@@ -471,6 +477,7 @@ type GetServicesByUserRow struct {
 	ServiceName   string
 	NodePorts     []int32
 	Ingress       pgtype.Text
+	CommitHash    pgtype.Text
 	ProjectName   string
 }
 
@@ -490,6 +497,7 @@ func (q *Queries) GetServicesByUser(ctx context.Context, userID uuid.UUID) ([]Ge
 			&i.ServiceName,
 			&i.NodePorts,
 			&i.Ingress,
+			&i.CommitHash,
 			&i.ProjectName,
 		); err != nil {
 			return nil, err
@@ -621,6 +629,27 @@ func (q *Queries) IsUserInProject(ctx context.Context, arg IsUserInProjectParams
 	return exists, err
 }
 
+const setServiceCommitHash = `-- name: SetServiceCommitHash :exec
+UPDATE
+  services
+SET
+  commit_hash = $2
+WHERE
+  id = $1
+RETURNING
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
+`
+
+type SetServiceCommitHashParams struct {
+	ID         uuid.UUID
+	CommitHash pgtype.Text
+}
+
+func (q *Queries) SetServiceCommitHash(ctx context.Context, arg SetServiceCommitHashParams) error {
+	_, err := q.db.Exec(ctx, setServiceCommitHash, arg.ID, arg.CommitHash)
+	return err
+}
+
 const setServiceIngress = `-- name: SetServiceIngress :exec
 UPDATE
   services
@@ -629,7 +658,7 @@ SET
 WHERE
   id = $1
 RETURNING
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 `
 
 type SetServiceIngressParams struct {
@@ -650,7 +679,7 @@ SET
 WHERE
   id = $1
 RETURNING
-  id, project_id, project_branch, service_name, node_ports, ingress
+  id, project_id, project_branch, service_name, node_ports, ingress, commit_hash
 `
 
 type SetServiceNodePortsParams struct {

--- a/internal/database/wrapper.go
+++ b/internal/database/wrapper.go
@@ -30,12 +30,28 @@ func (db *Database) EnsureSchema(ctx context.Context) error {
 		return fmt.Errorf("checking projects table existance: %w", err)
 	}
 
-	if exists {
+	if !exists {
+		if _, err := db.db.Exec(ctx, sql.Schema()); err != nil {
+			return fmt.Errorf("applying database schema: %w", err)
+		}
 		return nil
 	}
 
-	if _, err := db.db.Exec(ctx, sql.Schema()); err != nil {
-		return fmt.Errorf("applying database schema: %w", err)
+	if err := db.applyMigrations(ctx); err != nil {
+		return fmt.Errorf("applying migrations: %w", err)
+	}
+
+	return nil
+}
+
+// applyMigrations applies incremental schema changes to an existing database.
+func (db *Database) applyMigrations(ctx context.Context) error {
+	// Add commit_hash column to services table if it doesn't exist.
+	const addCommitHash = `
+		ALTER TABLE services ADD COLUMN IF NOT EXISTS commit_hash text NULL
+	`
+	if _, err := db.db.Exec(ctx, addCommitHash); err != nil {
+		return fmt.Errorf("adding commit_hash column: %w", err)
 	}
 
 	return nil

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -57,6 +57,7 @@ type DeployRequest struct {
 	Namespace        string
 	ProjectID        uuid.UUID
 	BranchName       string
+	CommitHash       string
 	ProjectConfig    Config
 	FileContent      []byte
 	ExistingServices []database.Service

--- a/internal/sql/query.sql
+++ b/internal/sql/query.sql
@@ -38,8 +38,8 @@ ORDER BY
   service_name;
 
 -- name: CreateService :one
-INSERT INTO services (id, project_id, project_branch, service_name, node_ports, ingress)
-  VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO services (id, project_id, project_branch, service_name, node_ports, ingress, commit_hash)
+  VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING
   *;
 
@@ -52,6 +52,16 @@ WHERE service_name = $1
 -- name: DeleteServiceById :exec
 DELETE FROM services
 WHERE id = $1;
+
+-- name: SetServiceCommitHash :exec
+UPDATE
+  services
+SET
+  commit_hash = $2
+WHERE
+  id = $1
+RETURNING
+  *;
 
 -- name: SetServiceNodePorts :exec
 UPDATE

--- a/internal/sql/schema.sql
+++ b/internal/sql/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE services (
   service_name text NOT NULL,
   node_ports integer[] NULL,
   ingress text NULL,
+  commit_hash text NULL,
   FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
   UNIQUE (project_id, project_branch, service_name)
 );


### PR DESCRIPTION
Store the git commit hash for each deployed service, rewrite image tags for non-template services to use the commit hash, and expose it in service list/detail API responses. Includes a migration for existing databases.