### PR TITLE
feat: volume node affinity, SPA ingress support, and ingress updates

### DIFF
--- a/internal/kubernetes/deployments.go
+++ b/internal/kubernetes/deployments.go
@@ -153,19 +153,31 @@ func GenerateDeploymentSpec(
 		}
 	}
 
+	var nodeSelectorRequirements []corev1.NodeSelectorRequirement
+
+	if len(service.Volumes) > 0 {
+		nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+			Key:      "kubernetes.io/hostname",
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"server-master"},
+		})
+	}
+
 	if service.Arch != "" {
+		nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{service.Arch},
+		})
+	}
+
+	if len(nodeSelectorRequirements) > 0 {
 		spec.Template.Spec.Affinity = &corev1.Affinity{
 			NodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
 						{
-							MatchExpressions: []corev1.NodeSelectorRequirement{
-								{
-									Key:      "kubernetes.io/arch",
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{service.Arch},
-								},
-							},
+							MatchExpressions: nodeSelectorRequirements,
 						},
 					},
 				},

--- a/internal/kubernetes/ingress.go
+++ b/internal/kubernetes/ingress.go
@@ -80,16 +80,22 @@ func GenerateIngressSpec(namespace string, service *models.Service,
 		},
 	}
 
+	annotations := map[string]string{
+		"created": time.Now().Format(time.RFC3339),
+		"nginx.ingress.kubernetes.io/ssl-redirect":      "true",
+		"nginx.ingress.kubernetes.io/cors-allow-origin": "*",
+		"cert-manager.io/cluster-issuer":                "letsencrypt-prod",
+	}
+
+	if service.SPA {
+		annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = "proxy_intercept_errors on;\nerror_page 404 =200 /index.html;\n"
+	}
+
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", service.Name, "ingress"),
 			Namespace: namespace,
-			Annotations: map[string]string{
-				"created": time.Now().Format(time.RFC3339),
-				"nginx.ingress.kubernetes.io/ssl-redirect":      "true",
-				"nginx.ingress.kubernetes.io/cors-allow-origin": "*",
-				"cert-manager.io/cluster-issuer":                "letsencrypt-prod",
-			},
+			Annotations: annotations,
 		},
 		Spec: spec,
 	}, nil
@@ -98,15 +104,28 @@ func GenerateIngressSpec(namespace string, service *models.Service,
 func CreateIngress(
 	ctx context.Context, namespace string, ingress *networkingv1.Ingress,
 ) (*networkingv1.Ingress, error) {
-	_, err := getClient().NetworkingV1().Ingresses(namespace).Create(
-		ctx, ingress, metav1.CreateOptions{})
-	if errors.IsAlreadyExists(err) {
-		return ingress, nil
+	client := getClient().NetworkingV1().Ingresses(namespace)
+
+	existing, err := client.Get(ctx, ingress.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		created, err := client.Create(ctx, ingress, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("creating ingress: %w", err)
+		}
+		return created, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting ingress: %w", err)
 	}
-	return ingress, nil
+
+	existing.Spec = ingress.Spec
+	existing.Annotations = ingress.Annotations
+
+	updated, err := client.Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("updating ingress: %w", err)
+	}
+	return updated, nil
 }
 
 func DeleteIngress(ctx context.Context, namespace, host string) error {

--- a/internal/kubernetes/ingress.go
+++ b/internal/kubernetes/ingress.go
@@ -87,8 +87,13 @@ func GenerateIngressSpec(namespace string, service *models.Service,
 		"cert-manager.io/cluster-issuer":                "letsencrypt-prod",
 	}
 
-	if service.SPA {
-		annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = "proxy_intercept_errors on;\nerror_page 404 =200 /index.html;\n"
+	for _, feature := range service.Features {
+		switch feature {
+		case "spa":
+			annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = "proxy_intercept_errors on;\nerror_page 404 =200 /index.html;\n"
+		case "grpc":
+			annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "GRPC"
+		}
 	}
 
 	return &networkingv1.Ingress{

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,7 +27,7 @@ type Service struct {
 	Template     string          `yaml:"template,omitempty"`
 	Version      string          `yaml:"version,omitempty"`
 	Arch         string          `yaml:"arch,omitempty"`
-	SPA          bool            `yaml:"spa,omitempty"`
+	Features     []string        `yaml:"features,omitempty"`
 	Configs      []ConfigEntry   `yaml:"configs,omitempty"`
 	Command      []string        `yaml:"command,omitempty"`
 	Args         []string        `yaml:"args,omitempty"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,6 +27,7 @@ type Service struct {
 	Template     string          `yaml:"template,omitempty"`
 	Version      string          `yaml:"version,omitempty"`
 	Arch         string          `yaml:"arch,omitempty"`
+	SPA          bool            `yaml:"spa,omitempty"`
 	Configs      []ConfigEntry   `yaml:"configs,omitempty"`
 	Command      []string        `yaml:"command,omitempty"`
 	Args         []string        `yaml:"args,omitempty"`


### PR DESCRIPTION
Pin deployments with volumes to server-master node via hostname affinity. Add spa config flag for try_files index.html fallback on ingress. Update existing ingresses on redeploy instead of skipping.